### PR TITLE
chore: remove unused import

### DIFF
--- a/griffe_inherited_method_crossrefs/__init__.py
+++ b/griffe_inherited_method_crossrefs/__init__.py
@@ -4,7 +4,6 @@ Derived from [griffe-inherited-docstrings](https://github.com/mkdocstrings/griff
 """
 
 import contextlib
-import copy
 from typing import TYPE_CHECKING
 from griffe import Extension, Docstring, Function
 from griffe.exceptions import AliasResolutionError


### PR DESCRIPTION
There is no need to import the `copy` module if it isn't actually used.