### PR TITLE
fix: exception import from griffe

### DIFF
--- a/griffe_inherited_method_crossrefs/__init__.py
+++ b/griffe_inherited_method_crossrefs/__init__.py
@@ -6,8 +6,7 @@ Derived from [griffe-inherited-docstrings](https://github.com/mkdocstrings/griff
 import contextlib
 import copy
 from typing import TYPE_CHECKING
-from griffe import Extension, Docstring, Function
-from griffe.exceptions import AliasResolutionError
+from griffe import AliasResolutionError, Extension, Docstring, Function
 
 if TYPE_CHECKING:
     from griffe import Module, Object


### PR DESCRIPTION
Griffe has restructed its codebase to hide everything behind a private `_griffe` module and publicly re-export what is strictly needed in `griffe`. As such, there are no `griffe` submodules.